### PR TITLE
Add compatibility for OpenFOAM v2406 and update library references

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Rettenmaier, Daniel, et al. "Load balanced 2D and 3D adaptive mesh refinement in
 link:
 https://www.sciencedirect.com/science/article/pii/S2352711018301699
 
-port to the OpenFOAM+ version v1812 and v2006,v2012
+port to the OpenFOAM+ version v1812, v2006, v2012 and v2406
 
 refinement selection algoritm is based on foam extended 4.1
 
 ## Getting Started
 
-install OpenFOAM v1812 
+install OpenFOAM v1812, v2006, v2012 or v2406
 
 compile the library
 ```
@@ -28,9 +28,20 @@ in case of v2006, v2012:
 git checkout v2012
 ./Allwmake
 ```
+for OpenFOAM v2406, source the v2406 environment and build this branch directly:
+```
+source /usr/lib/openfoam/openfoam2406/etc/bashrc
+./Allwmake
+```
+
+This branch includes compatibility fixes for OpenFOAM v2406 API changes
+including runtime selection tables, `mesh.data().setFinalIteration(...)`,
+`writeObject(IOstreamOption, bool)`, `HashTable` iterators and
+`CompactListList` packing.
+
 ### Prerequisites
 
-Requires OpenFOAM v1812 or v2006,v2012:
+Requires OpenFOAM v1812, v2006, v2012 or v2406:
 
 ```
 https://www.openfoam.com/download/release-history.php
@@ -45,13 +56,32 @@ https://www.openfoam.com/download/release-history.php
 ```
 ### Usage
 
-add following lines to the contolDict:
+add following lines to the controlDict:
 ```
 libs
 (
    "libdynamicLoadBalanceFvMesh.so"
 );
-or depending on the openfoam version
+```
+
+Do not use the old library name `libpolyRef.so` with this version. If an
+existing case still contains it, replace it with `libdynamicLoadBalanceFvMesh.so`.
+
+In the case `constant/dynamicMeshDict`, select one of the dynamic mesh types:
+```
+dynamicFvMesh   dynamicMultiDimRefineFvMesh;
+```
+or, when load balancing is required:
+```
+dynamicFvMesh   dynamicMultiDimRefineBalancedFvMesh;
+
+enableBalancing     true;
+allowableImbalance  0.10;
+```
+
+For older OpenFOAM versions, depending on the library loading syntax, the
+unquoted library name may also be used:
+```
 libs
 (
    dynamicLoadBalanceFvMesh

--- a/solver/chtMultiRegionDyMFoam/fluid/solveFluid.H
+++ b/solver/chtMultiRegionDyMFoam/fluid/solveFluid.H
@@ -1,6 +1,10 @@
 if (finalIter)
 {
+#if OPENFOAM >= 2206
+    mesh.data().setFinalIteration(true);
+#else
     mesh.data::add("finalIteration", true);
+#endif
 }
 
 if (frozenFlow)
@@ -73,5 +77,9 @@ else
 
 if (finalIter)
 {
+#if OPENFOAM >= 2206
+    mesh.data().setFinalIteration(false);
+#else
     mesh.data::remove("finalIteration");
+#endif
 }

--- a/solver/chtMultiRegionDyMFoam/solid/solveSolid.H
+++ b/solver/chtMultiRegionDyMFoam/solid/solveSolid.H
@@ -1,6 +1,10 @@
 if (finalIter)
 {
+#if OPENFOAM >= 2206
+    mesh.data().setFinalIteration(true);
+#else
     mesh.data::add("finalIteration", true);
+#endif
 }
 
 {
@@ -35,5 +39,9 @@ if (finalIter)
 
 if (finalIter)
 {
+#if OPENFOAM >= 2206
+    mesh.data().setFinalIteration(false);
+#else
     mesh.data::remove("finalIteration");
+#endif
 }

--- a/src/dynamicLoadBalanceFvMesh/adaptCriteria/adaptCriteria.C
+++ b/src/dynamicLoadBalanceFvMesh/adaptCriteria/adaptCriteria.C
@@ -67,10 +67,16 @@ Foam::autoPtr<Foam::adaptCriteria> Foam::adaptCriteria::New
     const word adaptCriteriaTypeName(dict.lookup("type"));
     Info<< "Creating adaptCriteria " << adaptCriteriaTypeName << endl;
 
+#if OPENFOAM >= 2206
+    auto cstr = dictionaryConstructorTable(adaptCriteriaTypeName);
+
+    if (!cstr)
+#else
     dictionaryConstructorTable::iterator cstrIter =
         dictionaryConstructorTablePtr_->find(adaptCriteriaTypeName);
 
     if (cstrIter == dictionaryConstructorTablePtr_->end())
+#endif
     {
         FatalErrorIn
             (
@@ -86,7 +92,11 @@ Foam::autoPtr<Foam::adaptCriteria> Foam::adaptCriteria::New
                 << exit(FatalError);
     }
 
+#if OPENFOAM >= 2206
+    return autoPtr<adaptCriteria>(cstr(mesh, dict));
+#else
     return autoPtr<adaptCriteria>(cstrIter()(mesh, dict));
+#endif
 }
 
 

--- a/src/dynamicLoadBalanceFvMesh/dynamicMultiDimRefineBalancedFvMesh/fvMeshDistributeAddPatch/fvMeshDistributeAddPatch.C
+++ b/src/dynamicLoadBalanceFvMesh/dynamicMultiDimRefineBalancedFvMesh/fvMeshDistributeAddPatch/fvMeshDistributeAddPatch.C
@@ -1479,7 +1479,11 @@ void Foam::fvMeshDistributeAddPatch::sendMesh
     // Send
     toDomain
         << mesh.points()
+#if OPENFOAM >= 2206
+        << CompactListList<label>::pack<face>(mesh.faces())
+#else
         << CompactListList<label, face>(mesh.faces())
+#endif
         << mesh.faceOwner()
         << mesh.faceNeighbour()
         << mesh.boundaryMesh()
@@ -1521,7 +1525,11 @@ Foam::autoPtr<Foam::fvMesh> Foam::fvMeshDistributeAddPatch::receiveMesh
 )
 {
     pointField domainPoints(fromNbr);
+#if OPENFOAM >= 2206
+    faceList domainFaces = CompactListList<label>(fromNbr).unpack<face>();
+#else
     faceList domainFaces = CompactListList<label, face>(fromNbr)();
+#endif
     labelList domainAllOwner(fromNbr);
     labelList domainAllNeighbour(fromNbr);
     PtrList<entry> patchEntries(fromNbr);

--- a/src/dynamicLoadBalanceFvMesh/dynamicMultiDimRefineFvMesh/dynamicMultiDimRefineFvMesh.C
+++ b/src/dynamicLoadBalanceFvMesh/dynamicMultiDimRefineFvMesh/dynamicMultiDimRefineFvMesh.C
@@ -595,7 +595,7 @@ Foam::dynamicMultiDimRefineFvMesh::unrefine
             forAllConstIters(faceToSplitPoint, iter)
             {
                 const label oldFacei = iter.key();
-                const label oldPointi = iter.object();
+                const label oldPointi = iter();
 
                 if (reversePointMap[oldPointi] < 0)
                 {
@@ -1274,21 +1274,33 @@ bool Foam::dynamicMultiDimRefineFvMesh::update()
 }
 
 
+#if OPENFOAM >= 2206
+bool Foam::dynamicMultiDimRefineFvMesh::writeObject
+(
+    IOstreamOption streamOpt,
+    const bool writeOnProc
+) const
+#else
 bool Foam::dynamicMultiDimRefineFvMesh::writeObject
 (
     IOstream::streamFormat fmt,
     IOstream::versionNumber ver,
     IOstream::compressionType cmp,
-    const bool valid
+    const bool writeOnProc
 ) const
+#endif
 {
     // Force refinement data to go to the current time directory.
     const_cast<hexRef&>(meshCutter_()).setInstance(time().timeName());
 
     bool writeOk =
     (
-        dynamicFvMesh::writeObject(fmt, ver, cmp, valid)
-     && meshCutter_->write(valid)
+#if OPENFOAM >= 2206
+        dynamicFvMesh::writeObject(streamOpt, writeOnProc)
+#else
+        dynamicFvMesh::writeObject(fmt, ver, cmp, writeOnProc)
+#endif
+     && meshCutter_->write(writeOnProc)
     );
 
     if (dumpLevel_)

--- a/src/dynamicLoadBalanceFvMesh/dynamicMultiDimRefineFvMesh/dynamicMultiDimRefineFvMesh.H
+++ b/src/dynamicLoadBalanceFvMesh/dynamicMultiDimRefineFvMesh/dynamicMultiDimRefineFvMesh.H
@@ -266,6 +266,13 @@ public:
     // Writing
 
         //- Write using given format, version and compression
+#if OPENFOAM >= 2206
+        virtual bool writeObject
+        (
+            IOstreamOption streamOpt,
+            const bool writeOnProc
+        ) const;
+#else
         virtual bool writeObject
         (
             IOstream::streamFormat fmt,
@@ -273,6 +280,7 @@ public:
             IOstream::compressionType cmp,
             const bool valid
         ) const;
+#endif
 };
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //

--- a/src/dynamicLoadBalanceFvMesh/hexRef/hexRefNew.C
+++ b/src/dynamicLoadBalanceFvMesh/hexRef/hexRefNew.C
@@ -61,10 +61,16 @@ Foam::autoPtr<Foam::hexRef> Foam::hexRef::New
         hexRefTypeName = "hexRef4";
     }
 
+#if OPENFOAM >= 2206
+    auto hexRefCtor = meshConstructorTable(hexRefTypeName);
+
+    if (!hexRefCtor)
+#else
     meshConstructorTable::iterator hexRefIter =
         meshConstructorTablePtr_->find(hexRefTypeName);
 
     if (hexRefIter == meshConstructorTablePtr_->end())
+#endif
     {
         FatalErrorInFunction
             << "Unsupported mesh number of dimensions for hex refinement" << nl
@@ -75,7 +81,11 @@ Foam::autoPtr<Foam::hexRef> Foam::hexRef::New
 
     return autoPtr<hexRef>
     (
+#if OPENFOAM >= 2206
+        hexRefCtor(mesh, readHistory)
+#else
         hexRefIter()(mesh, readHistory)
+#endif
     );
 }
 
@@ -112,10 +122,16 @@ Foam::autoPtr<Foam::hexRef> Foam::hexRef::New
         hexRefTypeName = "hexRef4";
     }
 
+#if OPENFOAM >= 2206
+    auto hexRefCtor = levelsHistConstructorTable(hexRefTypeName);
+
+    if (!hexRefCtor)
+#else
     levelsHistConstructorTable::iterator hexRefIter =
         levelsHistConstructorTablePtr_->find(hexRefTypeName);
 
     if (hexRefIter == levelsHistConstructorTablePtr_->end())
+#endif
     {
         FatalErrorInFunction
             << "Unsupported mesh number of dimensions for hex refinement" << nl
@@ -126,7 +142,11 @@ Foam::autoPtr<Foam::hexRef> Foam::hexRef::New
 
     return autoPtr<hexRef>
     (
+#if OPENFOAM >= 2206
+        hexRefCtor(mesh, cellLevel, pointLevel, history, level0Edge)
+#else
         hexRefIter()(mesh, cellLevel, pointLevel, history, level0Edge)
+#endif
     );
 }
 
@@ -162,10 +182,16 @@ Foam::autoPtr<Foam::hexRef> Foam::hexRef::New
         hexRefTypeName = "hexRef4";
     }
 
+#if OPENFOAM >= 2206
+    auto hexRefCtor = levelsConstructorTable(hexRefTypeName);
+
+    if (!hexRefCtor)
+#else
     levelsConstructorTable::iterator hexRefIter =
         levelsConstructorTablePtr_->find(hexRefTypeName);
 
     if (hexRefIter == levelsConstructorTablePtr_->end())
+#endif
     {
         FatalErrorInFunction
             << "Unsupported mesh number of dimensions for hex refinement" << nl
@@ -176,7 +202,11 @@ Foam::autoPtr<Foam::hexRef> Foam::hexRef::New
 
     return autoPtr<hexRef>
     (
+#if OPENFOAM >= 2206
+        hexRefCtor(mesh, cellLevel, pointLevel, level0Edge)
+#else
         hexRefIter()(mesh, cellLevel, pointLevel, level0Edge)
+#endif
     );
 }
 

--- a/test/test-2DHex/system/controlDict
+++ b/test/test-2DHex/system/controlDict
@@ -63,7 +63,7 @@ maxDeltaT       1;
 
 libs
 (
-    "libpolyRef.so"
+    "libdynamicLoadBalanceFvMesh.so"
 );
 
 


### PR DESCRIPTION
This pull request adds support and compatibility fixes for OpenFOAM v2406, ensuring the codebase works with the latest API while maintaining backward compatibility with previous OpenFOAM+ versions (v1812, v2006, v2012). The changes include conditional compilation for new/changed APIs, updates to documentation and usage instructions, and migration to the new library name.

**OpenFOAM v2406 compatibility:**

* Added conditional compilation throughout the codebase to support OpenFOAM v2406 API changes, including updates for runtime selection tables, `mesh.data().setFinalIteration`, `writeObject(IOstreamOption, bool)`, `HashTable` iterators, and `CompactListList` packing. 

**Documentation and usage updates:**

* Updated `README.md` to document support for OpenFOAM v2406, provide new build instructions, and clarify usage of the correct library name (`libdynamicLoadBalanceFvMesh.so`). Added explicit instructions for dynamic mesh selection and load balancing options. 
**Library and configuration migration:**

* Deprecated the old library name `libpolyRef.so` in favor of `libdynamicLoadBalanceFvMesh.so` and updated example configuration files accordingly. 
**Minor corrections:**

* Fixed a typo in the documentation (`contolDict` → `controlDict`).
* Updated a `HashTable` iterator usage for compatibility.